### PR TITLE
fix: Modify vue build command

### DIFF
--- a/app/console/web/Makefile
+++ b/app/console/web/Makefile
@@ -20,7 +20,7 @@ docker: build_linux
 
 .PHONY: vue
 vue:
-	cd vue && npm run build:prod
+	cd vue && npm install  && npm run build:prod
 
 .PHONY: statik
 statik:


### PR DESCRIPTION
添加 npm install , 否则首次执行会报:  `sh: vue-cli-service: command not found
`